### PR TITLE
Added ESP32 dimming support (and thus fixes compilation error)

### DIFF
--- a/src/LiquidCrystal_I2C.cpp
+++ b/src/LiquidCrystal_I2C.cpp
@@ -950,3 +950,21 @@ void LiquidCrystal_I2C::setBrightness(uint8_t pin, uint8_t value, backlightPolar
 
   analogWrite(pin, value);
 }
+
+	
+#if defined(ESP32)
+/**************************************************************************/
+/*
+    setLedChannel()
+
+    NOTE:
+    - this function is only defined when compiled for the ESP32
+    - use this function to select the ledc channel that this library should use.
+      the default is channel 14.
+*/
+/**************************************************************************/
+void LiquidCrystal_I2C::setLedChannel(uint8_t channel)
+{
+  ledChannel = channel;
+}	
+#endif // defined(ESP32)

--- a/src/LiquidCrystal_I2C.cpp
+++ b/src/LiquidCrystal_I2C.cpp
@@ -944,9 +944,17 @@ void LiquidCrystal_I2C::displayOn(void)
 /**************************************************************************/
 void LiquidCrystal_I2C::setBrightness(uint8_t pin, uint8_t value, backlightPolarity polarity)
 {
-  pinMode(pin, OUTPUT);
-
   if (polarity == NEGATIVE) value = 255 - value;
+#if defined(ESP32)
+  ledcAttachPin(pin, ledChannel);
+
+  // Change to 8-bit mode
+  ledcSetup(ledChannel, 5000, 8); // 5000Hz, 8-bits
+	
+  ledcWrite(ledChannel, value);
+#else
+  pinMode(pin, OUTPUT);	
 
   analogWrite(pin, value);
+#endif
 }

--- a/src/LiquidCrystal_I2C.h
+++ b/src/LiquidCrystal_I2C.h
@@ -218,6 +218,9 @@ class LiquidCrystal_I2C : public Print
    uint8_t _lcd_colums;
    uint8_t _lcd_rows;
    uint8_t _backlightValue;
+#if defined(ESP32)
+   uint8_t ledChannel;
+#endif // defined(ESP32)
    uint8_t _LCD_TO_PCF8574[8];
    bool    _PCF8574_initialisation;
 
@@ -232,6 +235,10 @@ class LiquidCrystal_I2C : public Print
           uint8_t readPCF8574(void);
           bool    readBusyFlag(void);
           uint8_t getCursorPosition(void);
+	  
+#if defined(ESP32)
+	  void setLedChannel(uint8_t channel);
+#endif // defined(ESP32)
 };
 
 #endif


### PR DESCRIPTION
When compiling for the ESP32, analogWrite is not defined. This is because the ESP32 uses led controllers (with 15 output channels)
This pull request adds those led controller thingies, only when being compiled for the ESP32 obviously